### PR TITLE
fix(ci): run prisma migrate from correct working directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,8 @@ jobs:
         run: bash scripts/init-db.sh
       - run: npx prisma generate --schema=libs/prisma-client/prisma/schema.prisma
       - name: Run migrations
-        run: npx prisma migrate deploy --schema=libs/prisma-client/prisma/schema.prisma
+        run: npx prisma migrate deploy --schema=prisma/schema.prisma
+        working-directory: libs/prisma-client
         env:
           DATABASE_URL: postgresql://roviq:roviq_dev@localhost:5432/roviq?schema=public
       - name: Run affected tests


### PR DESCRIPTION
## Summary

- Run `prisma migrate deploy` with `working-directory: libs/prisma-client` so Prisma finds `prisma.config.ts` and resolves the datasource URL
- Fixes: `The datasource.url property is required in your Prisma config file when using prisma migrate deploy`

## Test plan

- [x] Verified locally: `cd libs/prisma-client && DATABASE_URL=... npx prisma migrate deploy --schema=prisma/schema.prisma` succeeds
- [x] CI test job should pass after merge