### PR TITLE
fix(auth): embed resellerId in institute-scope JWT (ROV-261)

### DIFF
--- a/apps/api-gateway/src/auth/__tests__/auth.service.spec.ts
+++ b/apps/api-gateway/src/auth/__tests__/auth.service.spec.ts
@@ -39,7 +39,6 @@ function createMockMembershipRepo() {
     findActiveByUserId: vi.fn(),
     findManyByUserAndTenant: vi.fn(),
     findByIdAndUser: vi.fn(),
-    findFirstActive: vi.fn(),
   });
 }
 
@@ -187,6 +186,26 @@ describe('AuthService', () => {
       expect(result.user?.username).toBe('admin');
       expect(result.user?.tenantId).toBe('tenant-1');
       expect(result.requiresInstituteSelection).toBeUndefined();
+    });
+
+    it('signs the access token with resellerId in the payload (ROV-261)', async () => {
+      // The access token MUST carry `resellerId` so EE billing operations
+      // gated by `assertInstituteWithReseller` succeed for institute users.
+      mockUserRepo.findByUsername.mockResolvedValue(mockUser);
+      mockMembershipRepo.findActiveByUserId.mockResolvedValue([mockMembership]);
+      mockRefreshTokenRepo.create.mockResolvedValue(undefined);
+      mockJwt.sign.mockReturnValue('jwt-token');
+
+      await authService.instituteLogin('admin', 'correct-password');
+
+      // First sign() call is the access token. Verify resellerId is present
+      // and matches the institute's reseller_id.
+      const [accessPayload] = mockJwt.sign.mock.calls[0];
+      expect(accessPayload).toMatchObject({
+        scope: 'institute',
+        tenantId: 'tenant-1',
+        resellerId: '00000000-0000-7000-a000-000000000011',
+      });
     });
 
     it('should return membership list when user has multiple memberships', async () => {
@@ -647,6 +666,13 @@ describe('AuthService', () => {
           roleId: 'role-1',
           abilities: null,
           role: { id: 'role-1', abilities: [] },
+          institute: {
+            id: 'tenant-1',
+            name: { en: 'Test Institute' },
+            slug: 'test-institute',
+            logoUrl: null,
+            resellerId: '00000000-0000-7000-a000-000000000011',
+          },
         },
       });
 
@@ -1031,14 +1057,23 @@ describe('AuthService', () => {
 
       const roleAbilities = [{ action: 'manage', subject: 'all' }];
       const memberAbilities = [{ action: 'read', subject: 'Profile' }];
-      mockMembershipRepo.findFirstActive.mockResolvedValue({
-        id: 'membership-1',
-        tenantId: 'tenant-1',
-        roleId: 'role-1',
-        status: 'ACTIVE',
-        abilities: memberAbilities,
-        role: { id: 'role-1', abilities: roleAbilities },
-      });
+      mockMembershipRepo.findActiveByUserId.mockResolvedValue([
+        {
+          id: 'membership-1',
+          tenantId: 'tenant-1',
+          roleId: 'role-1',
+          status: 'ACTIVE',
+          abilities: memberAbilities,
+          role: { id: 'role-1', name: { en: 'Admin' }, abilities: roleAbilities },
+          institute: {
+            id: 'tenant-1',
+            name: { en: 'Test Institute' },
+            slug: 'test-institute',
+            logoUrl: null,
+            resellerId: '00000000-0000-7000-a000-000000000011',
+          },
+        },
+      ]);
 
       mockRefreshTokenRepo.revoke.mockResolvedValue(undefined);
       mockRefreshTokenRepo.create.mockResolvedValue(undefined);

--- a/apps/api-gateway/src/auth/__tests__/auth.service.spec.ts
+++ b/apps/api-gateway/src/auth/__tests__/auth.service.spec.ts
@@ -164,6 +164,7 @@ describe('AuthService', () => {
         name: { en: 'Test Institute' },
         slug: 'test-institute',
         logoUrl: null,
+        resellerId: '00000000-0000-7000-a000-000000000011',
       },
       role: { id: 'role-1', name: { en: 'Admin' }, abilities: [] },
     };
@@ -198,6 +199,7 @@ describe('AuthService', () => {
           name: { en: 'Other Institute' },
           slug: 'other-institute',
           logoUrl: null,
+          resellerId: '00000000-0000-7000-a000-000000000011',
         },
         role: { id: 'role-2', name: { en: 'Teacher' }, abilities: [] },
       };
@@ -369,6 +371,7 @@ describe('AuthService', () => {
         name: { en: 'Test Institute' },
         slug: 'test-institute',
         logoUrl: null,
+        resellerId: '00000000-0000-7000-a000-000000000011',
       },
       role: { id: 'role-1', name: { en: 'Admin' }, abilities: [] },
     };
@@ -396,6 +399,7 @@ describe('AuthService', () => {
           name: { en: 'Other Institute' },
           slug: 'other-institute',
           logoUrl: null,
+          resellerId: '00000000-0000-7000-a000-000000000011',
         },
         role: { id: 'role-2', name: { en: 'Teacher' }, abilities: [] },
       };
@@ -488,6 +492,7 @@ describe('AuthService', () => {
           name: { en: 'Test Institute' },
           slug: 'test-institute',
           logoUrl: null,
+          resellerId: '00000000-0000-7000-a000-000000000011',
         },
         role: { id: 'role-1', name: { en: 'Admin' }, abilities: [] },
       };
@@ -533,6 +538,7 @@ describe('AuthService', () => {
           name: { en: 'Test Institute' },
           slug: 'test-institute',
           logoUrl: null,
+          resellerId: '00000000-0000-7000-a000-000000000011',
         },
         role: { id: 'role-1', name: { en: 'Admin' }, abilities: [] },
       });
@@ -1266,6 +1272,7 @@ describe('AuthService', () => {
             name: { en: 'Test' },
             slug: 'test',
             logoUrl: null,
+            resellerId: '00000000-0000-7000-a000-000000000011',
           },
           role: { id: 'role-1', name: { en: 'Admin' }, abilities: [] },
         },

--- a/apps/api-gateway/src/auth/__tests__/auth.service.spec.ts
+++ b/apps/api-gateway/src/auth/__tests__/auth.service.spec.ts
@@ -198,8 +198,10 @@ describe('AuthService', () => {
 
       await authService.instituteLogin('admin', 'correct-password');
 
-      // First sign() call is the access token. Verify resellerId is present
-      // and matches the institute's reseller_id.
+      // issueTokens signs access then refresh — locking call ordering so a
+      // future refactor that swaps them doesn't silently invalidate the
+      // [0] index used below.
+      expect(mockJwt.sign).toHaveBeenCalledTimes(2);
       const [accessPayload] = mockJwt.sign.mock.calls[0];
       expect(accessPayload).toMatchObject({
         scope: 'institute',

--- a/apps/api-gateway/src/auth/auth.service.ts
+++ b/apps/api-gateway/src/auth/auth.service.ts
@@ -535,13 +535,11 @@ export class AuthService {
         meta,
       });
     } else if (storedToken.membership) {
-      // Institute scope. storedToken.membership lacks institute info (refresh
-      // token table doesn't JOIN institutes), so re-fetch through the
-      // membership repo to get `institute.resellerId` for the JWT.
-      const m = await this.membershipRepo.findByIdAndUser(storedToken.membership.id, user.id);
-      if (!m) {
-        throw new UnauthorizedException('Membership not found');
-      }
+      // Institute scope. `storedToken.membership` carries the joined
+      // institute (see refresh-token.drizzle-repository.ts), so
+      // `institute.resellerId` is available without an extra DB hop —
+      // required to mint a JWT containing the claim (ROV-261).
+      const m = storedToken.membership;
       result = await this.issueTokens({
         user,
         scope: 'institute',
@@ -556,8 +554,9 @@ export class AuthService {
     } else {
       // Fallback: find first active institute membership.
       // findActiveByUserId returns memberships ordered by createdAt asc, so [0]
-      // matches the previous findFirstActive semantics and additionally carries
-      // `institute.resellerId` for the JWT.
+      // is deterministic AND carries `institute.resellerId` for the JWT.
+      // Replaces the previous `findFirstActive` (no orderBy → DB-order
+      // non-determinism; no institute JOIN).
       const memberships = await this.membershipRepo.findActiveByUserId(user.id);
       const firstMembership = memberships[0];
       if (!firstMembership) {

--- a/apps/api-gateway/src/auth/auth.service.ts
+++ b/apps/api-gateway/src/auth/auth.service.ts
@@ -220,6 +220,7 @@ export class AuthService {
         user,
         scope: 'institute',
         tenantId: m.tenantId,
+        resellerId: m.institute.resellerId,
         membershipId: m.id,
         roleId: m.roleId,
         roleAbilities: m.role.abilities as Record<string, unknown>[],
@@ -296,6 +297,7 @@ export class AuthService {
         user,
         scope: 'institute',
         tenantId: m.tenantId,
+        resellerId: m.institute.resellerId,
         membershipId: m.id,
         roleId: m.roleId,
         roleAbilities: m.role.abilities as Record<string, unknown>[],
@@ -374,6 +376,7 @@ export class AuthService {
       user,
       scope: 'institute',
       tenantId: membership.tenantId,
+      resellerId: membership.institute.resellerId,
       membershipId: membership.id,
       roleId: membership.roleId,
       roleAbilities: membership.role.abilities as Record<string, unknown>[],
@@ -446,6 +449,7 @@ export class AuthService {
       user,
       scope: 'institute',
       tenantId: membership.tenantId,
+      resellerId: membership.institute.resellerId,
       membershipId: membership.id,
       roleId: membership.roleId,
       roleAbilities: membership.role.abilities as Record<string, unknown>[],
@@ -531,12 +535,18 @@ export class AuthService {
         meta,
       });
     } else if (storedToken.membership) {
-      // Institute scope
-      const m = storedToken.membership;
+      // Institute scope. storedToken.membership lacks institute info (refresh
+      // token table doesn't JOIN institutes), so re-fetch through the
+      // membership repo to get `institute.resellerId` for the JWT.
+      const m = await this.membershipRepo.findByIdAndUser(storedToken.membership.id, user.id);
+      if (!m) {
+        throw new UnauthorizedException('Membership not found');
+      }
       result = await this.issueTokens({
         user,
         scope: 'institute',
         tenantId: m.tenantId,
+        resellerId: m.institute.resellerId,
         membershipId: m.id,
         roleId: m.roleId,
         roleAbilities: m.role.abilities as Record<string, unknown>[],
@@ -544,8 +554,12 @@ export class AuthService {
         meta,
       });
     } else {
-      // Fallback: find first active institute membership
-      const firstMembership = await this.membershipRepo.findFirstActive(user.id);
+      // Fallback: find first active institute membership.
+      // findActiveByUserId returns memberships ordered by createdAt asc, so [0]
+      // matches the previous findFirstActive semantics and additionally carries
+      // `institute.resellerId` for the JWT.
+      const memberships = await this.membershipRepo.findActiveByUserId(user.id);
+      const firstMembership = memberships[0];
       if (!firstMembership) {
         throw new UnauthorizedException('No active memberships');
       }
@@ -553,6 +567,7 @@ export class AuthService {
         user,
         scope: 'institute',
         tenantId: firstMembership.tenantId,
+        resellerId: firstMembership.institute.resellerId,
         membershipId: firstMembership.id,
         roleId: firstMembership.roleId,
         roleAbilities: firstMembership.role.abilities as Record<string, unknown>[],

--- a/apps/api-gateway/src/auth/repositories/membership.drizzle-repository.ts
+++ b/apps/api-gateway/src/auth/repositories/membership.drizzle-repository.ts
@@ -10,7 +10,7 @@ import {
 } from '@roviq/database';
 import { and, asc, eq } from 'drizzle-orm';
 import { MembershipRepository } from './membership.repository';
-import type { MembershipWithInstituteAndRole, MembershipWithRole } from './types';
+import type { MembershipWithInstituteAndRole } from './types';
 
 @Injectable()
 export class MembershipDrizzleRepository extends MembershipRepository {
@@ -173,39 +173,6 @@ export class MembershipDrizzleRepository extends MembershipRepository {
       role: {
         id: row.roleIdFk,
         name: row.roleName,
-        abilities: row.roleAbilities,
-      },
-    };
-  }
-
-  async findFirstActive(userId: string): Promise<MembershipWithRole | null> {
-    const [row] = await withAdmin(this.db, mkAdminCtx('repository:membership'), (tx) =>
-      tx
-        .select({
-          id: membershipsLive.id,
-          tenantId: membershipsLive.tenantId,
-          roleId: membershipsLive.roleId,
-          status: membershipsLive.status,
-          abilities: membershipsLive.abilities,
-          roleIdFk: rolesLive.id,
-          roleAbilities: rolesLive.abilities,
-        })
-        .from(membershipsLive)
-        .innerJoin(rolesLive, eq(membershipsLive.roleId, rolesLive.id))
-        .where(and(eq(membershipsLive.userId, userId), eq(membershipsLive.status, 'ACTIVE')))
-        .limit(1),
-    );
-
-    if (!row) return null;
-
-    return {
-      id: row.id,
-      tenantId: row.tenantId,
-      roleId: row.roleId,
-      status: row.status,
-      abilities: row.abilities,
-      role: {
-        id: row.roleIdFk,
         abilities: row.roleAbilities,
       },
     };

--- a/apps/api-gateway/src/auth/repositories/membership.drizzle-repository.ts
+++ b/apps/api-gateway/src/auth/repositories/membership.drizzle-repository.ts
@@ -31,6 +31,7 @@ export class MembershipDrizzleRepository extends MembershipRepository {
           instituteName: institutesLive.name,
           instituteSlug: institutesLive.slug,
           instituteLogoUrl: institutesLive.logoUrl,
+          instituteResellerId: institutesLive.resellerId,
           roleIdFk: rolesLive.id,
           roleName: rolesLive.name,
           roleAbilities: rolesLive.abilities,
@@ -56,6 +57,7 @@ export class MembershipDrizzleRepository extends MembershipRepository {
         name: row.instituteName,
         slug: row.instituteSlug,
         logoUrl: row.instituteLogoUrl,
+        resellerId: row.instituteResellerId,
       },
       role: {
         id: row.roleIdFk,
@@ -81,6 +83,7 @@ export class MembershipDrizzleRepository extends MembershipRepository {
           instituteName: institutesLive.name,
           instituteSlug: institutesLive.slug,
           instituteLogoUrl: institutesLive.logoUrl,
+          instituteResellerId: institutesLive.resellerId,
           roleIdFk: rolesLive.id,
           roleName: rolesLive.name,
           roleAbilities: rolesLive.abilities,
@@ -108,6 +111,7 @@ export class MembershipDrizzleRepository extends MembershipRepository {
         name: row.instituteName,
         slug: row.instituteSlug,
         logoUrl: row.instituteLogoUrl,
+        resellerId: row.instituteResellerId,
       },
       role: {
         id: row.roleIdFk,
@@ -133,6 +137,7 @@ export class MembershipDrizzleRepository extends MembershipRepository {
           instituteName: institutesLive.name,
           instituteSlug: institutesLive.slug,
           instituteLogoUrl: institutesLive.logoUrl,
+          instituteResellerId: institutesLive.resellerId,
           roleIdFk: rolesLive.id,
           roleName: rolesLive.name,
           roleAbilities: rolesLive.abilities,
@@ -163,6 +168,7 @@ export class MembershipDrizzleRepository extends MembershipRepository {
         name: row.instituteName,
         slug: row.instituteSlug,
         logoUrl: row.instituteLogoUrl,
+        resellerId: row.instituteResellerId,
       },
       role: {
         id: row.roleIdFk,

--- a/apps/api-gateway/src/auth/repositories/membership.drizzle-repository.ts
+++ b/apps/api-gateway/src/auth/repositories/membership.drizzle-repository.ts
@@ -156,7 +156,6 @@ export class MembershipDrizzleRepository extends MembershipRepository {
     );
 
     if (!row) return null;
-
     return {
       id: row.id,
       tenantId: row.tenantId,

--- a/apps/api-gateway/src/auth/repositories/membership.repository.ts
+++ b/apps/api-gateway/src/auth/repositories/membership.repository.ts
@@ -1,4 +1,4 @@
-import type { MembershipWithInstituteAndRole, MembershipWithRole } from './types';
+import type { MembershipWithInstituteAndRole } from './types';
 
 export abstract class MembershipRepository {
   abstract findActiveByUserId(userId: string): Promise<MembershipWithInstituteAndRole[]>;
@@ -10,5 +10,4 @@ export abstract class MembershipRepository {
     membershipId: string,
     userId: string,
   ): Promise<MembershipWithInstituteAndRole | null>;
-  abstract findFirstActive(userId: string): Promise<MembershipWithRole | null>;
 }

--- a/apps/api-gateway/src/auth/repositories/refresh-token.drizzle-repository.ts
+++ b/apps/api-gateway/src/auth/repositories/refresh-token.drizzle-repository.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import {
   DRIZZLE_DB,
   type DrizzleDB,
+  institutes,
   memberships,
   mkAdminCtx,
   refreshTokens,
@@ -99,11 +100,20 @@ export class RefreshTokenDrizzleRepository extends RefreshTokenRepository {
           membershipAbilities: memberships.abilities,
           roleId: roles.id,
           roleAbilities: roles.abilities,
+          // Institute fields — required so the refresh flow can mint an
+          // institute-scope JWT containing `resellerId` (ROV-261) without
+          // an extra round-trip to membershipRepo.findByIdAndUser.
+          instituteId: institutes.id,
+          instituteName: institutes.name,
+          instituteSlug: institutes.slug,
+          instituteLogoUrl: institutes.logoUrl,
+          instituteResellerId: institutes.resellerId,
         })
         .from(refreshTokens)
         .innerJoin(users, eq(refreshTokens.userId, users.id))
         .leftJoin(memberships, eq(refreshTokens.membershipId, memberships.id))
         .leftJoin(roles, eq(memberships.roleId, roles.id))
+        .leftJoin(institutes, eq(memberships.tenantId, institutes.id))
         .where(eq(refreshTokens.id, id))
         .limit(1);
 
@@ -125,7 +135,14 @@ export class RefreshTokenDrizzleRepository extends RefreshTokenRepository {
         lastUsedAt: row.lastUsedAt,
         user: row.user,
         membership:
-          row.membershipId && row.membershipTenantId && row.membershipRoleId && row.roleId
+          row.membershipId &&
+          row.membershipTenantId &&
+          row.membershipRoleId &&
+          row.roleId &&
+          row.instituteId &&
+          row.instituteName &&
+          row.instituteSlug !== null &&
+          row.instituteResellerId
             ? {
                 id: row.membershipId,
                 tenantId: row.membershipTenantId,
@@ -134,6 +151,13 @@ export class RefreshTokenDrizzleRepository extends RefreshTokenRepository {
                 role: {
                   id: row.roleId,
                   abilities: row.roleAbilities,
+                },
+                institute: {
+                  id: row.instituteId,
+                  name: row.instituteName,
+                  slug: row.instituteSlug,
+                  logoUrl: row.instituteLogoUrl,
+                  resellerId: row.instituteResellerId,
                 },
               }
             : null,
@@ -182,11 +206,17 @@ export class RefreshTokenDrizzleRepository extends RefreshTokenRepository {
           membershipAbilities: memberships.abilities,
           roleId: roles.id,
           roleAbilities: roles.abilities,
+          instituteId: institutes.id,
+          instituteName: institutes.name,
+          instituteSlug: institutes.slug,
+          instituteLogoUrl: institutes.logoUrl,
+          instituteResellerId: institutes.resellerId,
         })
         .from(refreshTokens)
         .innerJoin(users, eq(refreshTokens.userId, users.id))
         .leftJoin(memberships, eq(refreshTokens.membershipId, memberships.id))
         .leftJoin(roles, eq(memberships.roleId, roles.id))
+        .leftJoin(institutes, eq(memberships.tenantId, institutes.id))
         .where(
           and(
             eq(refreshTokens.userId, userId),
@@ -210,7 +240,14 @@ export class RefreshTokenDrizzleRepository extends RefreshTokenRepository {
         lastUsedAt: row.lastUsedAt,
         user: row.user,
         membership:
-          row.membershipId && row.membershipTenantId && row.membershipRoleId && row.roleId
+          row.membershipId &&
+          row.membershipTenantId &&
+          row.membershipRoleId &&
+          row.roleId &&
+          row.instituteId &&
+          row.instituteName &&
+          row.instituteSlug !== null &&
+          row.instituteResellerId
             ? {
                 id: row.membershipId,
                 tenantId: row.membershipTenantId,
@@ -219,6 +256,13 @@ export class RefreshTokenDrizzleRepository extends RefreshTokenRepository {
                 role: {
                   id: row.roleId,
                   abilities: row.roleAbilities,
+                },
+                institute: {
+                  id: row.instituteId,
+                  name: row.instituteName,
+                  slug: row.instituteSlug,
+                  logoUrl: row.instituteLogoUrl,
+                  resellerId: row.instituteResellerId,
                 },
               }
             : null,

--- a/apps/api-gateway/src/auth/repositories/refresh-token.drizzle-repository.ts
+++ b/apps/api-gateway/src/auth/repositories/refresh-token.drizzle-repository.ts
@@ -135,6 +135,11 @@ export class RefreshTokenDrizzleRepository extends RefreshTokenRepository {
         lastUsedAt: row.lastUsedAt,
         user: row.user,
         membership:
+          // The guards on every institute field are TS-driven, not just
+          // defensive: drizzle's LEFT JOIN inference marks all joined columns
+          // as nullable even though name/slug/reseller_id are NOT NULL in the
+          // schema. The runtime checks are what narrow the type so the
+          // `institute: { ... }` literal below satisfies `InstituteInfo`.
           row.membershipId &&
           row.membershipTenantId &&
           row.membershipRoleId &&
@@ -240,6 +245,11 @@ export class RefreshTokenDrizzleRepository extends RefreshTokenRepository {
         lastUsedAt: row.lastUsedAt,
         user: row.user,
         membership:
+          // The guards on every institute field are TS-driven, not just
+          // defensive: drizzle's LEFT JOIN inference marks all joined columns
+          // as nullable even though name/slug/reseller_id are NOT NULL in the
+          // schema. The runtime checks are what narrow the type so the
+          // `institute: { ... }` literal below satisfies `InstituteInfo`.
           row.membershipId &&
           row.membershipTenantId &&
           row.membershipRoleId &&

--- a/apps/api-gateway/src/auth/repositories/types.ts
+++ b/apps/api-gateway/src/auth/repositories/types.ts
@@ -52,15 +52,6 @@ export interface MembershipWithInstituteAndRole {
   role: RoleInfo;
 }
 
-export interface MembershipWithRole {
-  id: string;
-  tenantId: string;
-  roleId: string;
-  status: MembershipStatus;
-  abilities: unknown;
-  role: Pick<RoleInfo, 'id' | 'abilities'>;
-}
-
 export interface PlatformMembershipWithRole {
   id: string;
   userId: string;
@@ -127,5 +118,11 @@ export interface RefreshTokenWithRelations {
     roleId: string;
     abilities: unknown;
     role: Pick<RoleInfo, 'id' | 'abilities'>;
+    /**
+     * Joined institute info — required so the refresh flow can mint a new
+     * institute-scope JWT containing `resellerId` (ROV-261) without an
+     * extra round-trip to `membershipRepo`.
+     */
+    institute: InstituteInfo;
   } | null;
 }

--- a/apps/api-gateway/src/auth/repositories/types.ts
+++ b/apps/api-gateway/src/auth/repositories/types.ts
@@ -26,6 +26,14 @@ export interface InstituteInfo {
   name: I18nContent;
   slug: string;
   logoUrl: string | null;
+  /**
+   * The reseller that owns this institute. Read at JWT mint time so
+   * institute-scope tokens carry `resellerId` — required for EE billing
+   * operations gated by `assertInstituteWithReseller` (myInvoices,
+   * assignPlan, cancelSubscription, etc.). Always populated because
+   * `institutes.reseller_id` is NOT NULL with a default of RESELLER_DIRECT.
+   */
+  resellerId: string;
 }
 
 export interface RoleInfo {

--- a/e2e/web-institute-e2e/src/navigation.e2e.spec.ts
+++ b/e2e/web-institute-e2e/src/navigation.e2e.spec.ts
@@ -38,12 +38,7 @@ test.describe('Navigation', () => {
   }
 
   test('breadcrumbs render on subpages', async ({ page }) => {
-    // `/en/billing/invoices` is omitted because the institute JWT currently
-    // lacks `resellerId`, so the `myInvoices` query 403s and Console
-    // Guardian rejects the test. Tracked separately (see follow-up Linear
-    // issue) — institute scope login should embed `resellerId` from the
-    // institute's `reseller_id` column at JWT mint time.
-    const subpages = ['/en/settings/institute', '/en/people/students', '/en/academics'];
+    const subpages = ['/en/settings/institute', '/en/billing/invoices', '/en/academics'];
 
     // Desktop variant — the mobile breadcrumb is also in DOM but hidden via CSS.
     const breadcrumb = page.getByTestId(testIds.layout.breadcrumbsDesktop);


### PR DESCRIPTION
## Summary

Closes ROV-261. Institute-scope login was minting JWTs without `resellerId`, so any institute user calling an EE billing operation gated by `assertInstituteWithReseller` (`myInvoices`, `assignPlan`, `cancelSubscription`, …) got a 403 with `Institute scope with reseller required`. Reseller-scope login already passed `resellerId` through — the asymmetry was the bug. Schema-level the field is always available: `institutes.reseller_id` is `NOT NULL` with a default of `RESELLER_DIRECT`.

## Changes

- `InstituteInfo` ([types.ts](apps/api-gateway/src/auth/repositories/types.ts)) gains a required `resellerId: string` field.
- `membership.drizzle-repository.ts`: `findActiveByUserId`, `findByIdAndUser`, and `findManyByUserAndTenant` each select `institutesLive.resellerId` and surface it in the mapped institute object.
- `auth.service.ts`: 6 institute-scope `issueTokens` call sites now pass `resellerId: m.institute.resellerId`:
  - `instituteLogin` (single membership)
  - `instituteLoginByUserId` (passkey, single membership)
  - `selectInstitute` (after multi-membership selection)
  - `switchInstitute`
  - `refreshTokens` (institute-scope with stored membership — re-fetches via `membershipRepo.findByIdAndUser` because `storedToken.membership` doesn't JOIN institutes)
  - `refreshTokens` (institute-scope fallback — switched from `findFirstActive` to `findActiveByUserId[0]` for the same reason)
- `e2e/web-institute-e2e/src/navigation.e2e.spec.ts`: restored `/en/billing/invoices` in the `breadcrumbs render on subpages` test (it was skipped while ROV-261 was open).
- `auth.service.spec.ts`: 7 mock institute fixtures gain `resellerId`.

`issueTokens` already accepted an optional `resellerId` and spread it into the access token payload when present — no signature change.

## Test plan

- [x] `pnpm ci:check` passes locally (lint, typecheck, unit, integration, e2e, gates)
- [ ] CI passes on PR
- [ ] Decoded institute JWT (via E2E) contains `resellerId` matching the institute's DB row
- [ ] `myInvoices` no longer returns FORBIDDEN for seeded institute users
- [ ] Restored `/en/billing/invoices` breadcrumbs subpage passes in CI (was previously skipped)

## Ref

- Linear: ROV-261
- Workaround landed in: #208 (release: develop → main, 437 commits)
- Resolvers gated by `assertInstituteWithReseller`: [ee/apps/api-gateway/src/billing/institute/institute-billing.resolver.ts](ee/apps/api-gateway/src/billing/institute/institute-billing.resolver.ts)