### PR TITLE
test(e2e): extract waitForSetupComplete helper for institute setup race (ROV-262)

### DIFF
--- a/e2e/api-gateway-e2e/src/helpers/wait-for-setup-complete.ts
+++ b/e2e/api-gateway-e2e/src/helpers/wait-for-setup-complete.ts
@@ -18,6 +18,10 @@ import { gql } from './gql-client';
  *   running out the clock on a setup that will never reach COMPLETED.
  * - Tolerates transient network errors (api-gateway restart mid-test,
  *   socket hiccups) — a single failed poll does not abort the wait.
+ * - On timeout, the assertion message includes the last-observed status
+ *   AND the last network error — without these, "did not complete in 15s"
+ *   masks the actual failure mode (stuck-in-IN_PROGRESS vs api-gateway
+ *   never reachable).
  *
  * Tracked by ROV-262 — surfaced after the institute-admin academic-tree
  * test flaked in CI for PR #208 while passing locally.
@@ -28,6 +32,8 @@ export async function waitForSetupComplete(
   timeoutMs = 15_000,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
+  let lastStatus: SetupStatus | undefined;
+  let lastError: unknown;
   while (Date.now() < deadline) {
     let status: SetupStatus | undefined;
     try {
@@ -39,9 +45,12 @@ export async function waitForSetupComplete(
         adminToken,
       );
       status = res.data?.adminGetInstitute.setupStatus;
-    } catch {
-      // Transient — keep polling until the deadline.
+      lastError = undefined;
+    } catch (err) {
+      // Transient — keep polling until the deadline. Stash for diagnostics.
+      lastError = err;
     }
+    if (status !== undefined) lastStatus = status;
     if (status === SetupStatus.COMPLETED) return;
     if (status === SetupStatus.FAILED) {
       assert.fail(
@@ -50,5 +59,15 @@ export async function waitForSetupComplete(
     }
     await new Promise((r) => setTimeout(r, 200));
   }
-  assert.fail(`Setup did not complete within ${timeoutMs}ms for institute ${instituteId}`);
+  const tail = [
+    `lastStatus=${lastStatus ?? '<never observed>'}`,
+    lastError
+      ? `lastError=${lastError instanceof Error ? lastError.message : String(lastError)}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  assert.fail(
+    `Setup did not complete within ${timeoutMs}ms for institute ${instituteId} (${tail})`,
+  );
 }

--- a/e2e/api-gateway-e2e/src/helpers/wait-for-setup-complete.ts
+++ b/e2e/api-gateway-e2e/src/helpers/wait-for-setup-complete.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { SetupStatus } from '@roviq/common-types';
+import { gql } from './gql-client';
+
+/**
+ * Poll `adminGetInstitute` until `setupStatus === SetupStatus.COMPLETED`.
+ *
+ * `institute.service.create()` fires `setupService.runSetup()` as
+ * fire-and-forget. Any test that queries an institute's derived state
+ * (academic tree, standards, sections, etc.) immediately after creation
+ * MUST wait for setup to finish to avoid race-condition flakes.
+ *
+ * Default 15 s timeout — Phase 1 (`createFirstAcademicYear`) typically
+ * completes within ~200 ms, Phase 2 (full SCHOOL seed) under ~2 s.
+ *
+ * Robustness:
+ * - Short-circuits with a clear error on `SetupStatus.FAILED` rather than
+ *   running out the clock on a setup that will never reach COMPLETED.
+ * - Tolerates transient network errors (api-gateway restart mid-test,
+ *   socket hiccups) — a single failed poll does not abort the wait.
+ *
+ * Tracked by ROV-262 — surfaced after the institute-admin academic-tree
+ * test flaked in CI for PR #208 while passing locally.
+ */
+export async function waitForSetupComplete(
+  instituteId: string,
+  adminToken: string,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    let status: SetupStatus | undefined;
+    try {
+      const res = await gql<{ adminGetInstitute: { setupStatus: SetupStatus } }>(
+        `query WaitForSetupComplete_InstituteStatus($id: ID!) {
+          adminGetInstitute(id: $id) { setupStatus }
+        }`,
+        { id: instituteId },
+        adminToken,
+      );
+      status = res.data?.adminGetInstitute.setupStatus;
+    } catch {
+      // Transient — keep polling until the deadline.
+    }
+    if (status === SetupStatus.COMPLETED) return;
+    if (status === SetupStatus.FAILED) {
+      assert.fail(
+        `Setup FAILED for institute ${instituteId} — runSetup() crashed or hit an unrecoverable error`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  assert.fail(`Setup did not complete within ${timeoutMs}ms for institute ${instituteId}`);
+}

--- a/e2e/api-gateway-e2e/src/institute-admin.api-e2e.spec.ts
+++ b/e2e/api-gateway-e2e/src/institute-admin.api-e2e.spec.ts
@@ -15,6 +15,7 @@ import {
 } from './__generated__/graphql';
 import { loginAsPlatformAdmin } from './helpers/auth';
 import { gql } from './helpers/gql-client';
+import { waitForSetupComplete } from './helpers/wait-for-setup-complete';
 
 /**
  * Institute platform-scope E2E (migrated from hurl/institute/01-10).
@@ -945,17 +946,7 @@ describe('Institute Admin (platform scope) E2E', () => {
       assert(createRes.data);
       const id = createRes.data.adminCreateInstitute.id;
 
-      // Poll until setupService.runSetup() finishes — avoids querying mid-setup.
-      const deadline = Date.now() + 15_000;
-      while (Date.now() < deadline) {
-        const statusRes = await gql<{ adminGetInstitute: { setupStatus: string } }>(
-          `query Status($id: ID!) { adminGetInstitute(id: $id) { setupStatus } }`,
-          { id },
-          adminToken,
-        );
-        if (statusRes.data?.adminGetInstitute.setupStatus === 'COMPLETED') break;
-        await new Promise((r) => setTimeout(r, 200));
-      }
+      await waitForSetupComplete(id, adminToken);
 
       const treeRes = await gql<{
         adminGetInstituteAcademicTree: {


### PR DESCRIPTION
## Summary

Closes ROV-262. `institute.service.create()` fires `setupService.runSetup()` as fire-and-forget. Any E2E test that creates an institute and queries its derived state immediately races against the setup workflow. Today's only offender — [institute-admin.api-e2e.spec.ts:961](e2e/api-gateway-e2e/src/institute-admin.api-e2e.spec.ts#L961) — flaked in CI for PR #208 while passing locally because of timing skew. This PR extracts the inline poll loop into a shared helper before the copy-paste happens.

## Changes

- `e2e/api-gateway-e2e/src/helpers/wait-for-setup-complete.ts` — new helper.
- `e2e/api-gateway-e2e/src/institute-admin.api-e2e.spec.ts` — uses the helper instead of the inline poll loop.

## Helper improvements over the inlined version

- **Short-circuit on `SetupStatus.FAILED`** — clear error instead of polling out the full 15s timeout when setup will never reach COMPLETED.
- **Network-error tolerance** — single failed poll iteration does not abort the wait (handles api-gateway restarts / transient socket errors).
- **Typed against `SetupStatus` enum** from `@roviq/common-types` — a typo'd literal (`'COMPLETE'` vs `'COMPLETED'`) is a compile error.
- **Operation name prefixed** (`WaitForSetupComplete_InstituteStatus`) to avoid collisions with other admin status queries.

## Audit results

Grep'd `e2e/web-{admin,institute,reseller}-e2e` and `e2e/cross-portal` for `adminCreateInstitute` / `create-institute` UI flows. Only [forms-improved.e2e.spec.ts](e2e/web-admin-e2e/src/forms-improved.e2e.spec.ts) in web-admin-e2e clicks the submit button, and only to surface validation errors on blank/partial forms — it never persists an institute. **No other test in the suite has the race today.**

## Follow-up (out of scope)

The fire-and-forget pattern in `institute.service.create()` is the deeper problem — see ROV-262 description. Worth a separate spike: either await `runSetup()` synchronously, or run it as a Temporal workflow with `setupStatus` as the source of truth (resolver already emits it).

## Test plan

- [x] `pnpm ci:check` passes locally (lint, typecheck, unit, integration, e2e, gates)
- [x] Migrated academic-tree test passes in isolation
- [ ] CI passes on PR

## Ref

- Linear: ROV-262
- Surfaced in: PR #208, CI run [26174933098](https://github.com/Roviq-HQ/roviq/actions/runs/26174933098)