### PR TITLE
test(impersonation): e2e for admin scope filter + reseller sessions page (ROV-144)

### DIFF
--- a/apps/web/src/app/[locale]/institute/login/page.tsx
+++ b/apps/web/src/app/[locale]/institute/login/page.tsx
@@ -1,25 +1,61 @@
 'use client';
 
-import { LoginForm, useAuth } from '@roviq/auth';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@roviq/ui';
+import { LoginForm, sanitizeReturnUrl, useAuth } from '@roviq/auth';
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from '@roviq/ui';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import * as React from 'react';
+import { toast } from 'sonner';
 
 const { auth } = testIds;
 export default function LoginPage() {
   const t = useTranslations('auth');
-  const { isAuthenticated, needsInstituteSelection } = useAuth();
+  const { isAuthenticated, needsInstituteSelection, login } = useAuth();
   const router = useRouter();
+  const [quickLoading, setQuickLoading] = React.useState<string | null>(null);
+
+  // Dev-only one-click sign-in for the seeded accounts (gated to non-production below).
+  const devUsers = [
+    { role: t('devRoleAdmin'), username: 'admin', password: 'admin123', hint: t('devHintPicker') },
+    {
+      role: t('devRoleTeacher'),
+      username: 'teacher1',
+      password: 'teacher123',
+      hint: t('devHintDirect'),
+    },
+    {
+      role: t('devRoleStudent'),
+      username: 'student1',
+      password: 'student123',
+      hint: t('devHintDirect'),
+    },
+  ];
+  const quickLogin = async (user: { username: string; password: string }) => {
+    setQuickLoading(user.username);
+    try {
+      await login({ username: user.username, password: user.password });
+    } catch {
+      setQuickLoading(null);
+      toast.error(t('loginFailed'));
+    }
+  };
 
   React.useEffect(() => {
+    const returnUrl = sanitizeReturnUrl(
+      new URLSearchParams(window.location.search).get('returnUrl'),
+    );
     if (needsInstituteSelection) {
-      router.replace('/select-institute');
+      // Carry the post-login target through institute selection so the user lands
+      // on the page they originally requested, not a hardcoded dashboard.
+      router.replace(
+        returnUrl
+          ? `/select-institute?returnUrl=${encodeURIComponent(returnUrl)}`
+          : '/select-institute',
+      );
       return;
     }
     if (isAuthenticated) {
-      const params = new URLSearchParams(window.location.search);
-      router.replace(params.get('returnUrl') ?? '/dashboard');
+      router.replace(returnUrl ?? '/dashboard');
     }
   }, [isAuthenticated, needsInstituteSelection, router]);
 
@@ -51,14 +87,9 @@ export default function LoginPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <LoginForm
-              scope="institute"
-              labels={labels}
-              onSuccess={() => {
-                const params = new URLSearchParams(window.location.search);
-                router.replace(params.get('returnUrl') ?? '/dashboard');
-              }}
-            />
+            {/* Post-login navigation (incl. multi-institute selection + returnUrl) is
+                handled by the effect above, which reacts to the auth state reliably. */}
+            <LoginForm scope="institute" labels={labels} />
           </CardContent>
         </Card>
         {process.env.NODE_ENV !== 'production' && (
@@ -67,19 +98,26 @@ export default function LoginPage() {
               <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 {t('devCredentials')}
               </p>
-              <div className="space-y-1 font-mono text-xs text-muted-foreground">
-                <div>
-                  <span className="font-medium text-foreground">admin</span> / admin123
-                  <span className="ms-2 text-[10px]">({t('multiInstitutePicker')})</span>
-                </div>
-                <div>
-                  <span className="font-medium text-foreground">teacher1</span> / teacher123
-                  <span className="ms-2 text-[10px]">({t('singleInstitute')})</span>
-                </div>
-                <div>
-                  <span className="font-medium text-foreground">student1</span> / student123
-                  <span className="ms-2 text-[10px]">({t('singleInstitute')})</span>
-                </div>
+              <div className="space-y-1.5">
+                {devUsers.map((user) => (
+                  <Button
+                    key={user.username}
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={quickLoading !== null}
+                    onClick={() => quickLogin(user)}
+                    className="flex h-auto w-full items-center justify-between gap-2 font-mono text-xs"
+                    data-testid={auth.devQuickLogin(user.username)}
+                  >
+                    <span>
+                      <span className="font-medium">{user.username}</span> / {user.password}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {quickLoading === user.username ? t('signingIn') : user.hint}
+                    </span>
+                  </Button>
+                ))}
               </div>
             </CardContent>
           </Card>

--- a/apps/web/src/app/[locale]/institute/select-institute/__tests__/page.spec.tsx
+++ b/apps/web/src/app/[locale]/institute/select-institute/__tests__/page.spec.tsx
@@ -1,0 +1,80 @@
+/**
+ * Regression — select-institute must honour the post-login returnUrl.
+ *
+ * Bug: a multi-institute user bounced from a protected page to /login was sent
+ * to /select-institute without the returnUrl, and selection hardcoded /dashboard,
+ * so they never returned to the page they originally requested.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../__test-utils__/render-with-providers';
+
+const replace = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace, push: vi.fn(), prefetch: vi.fn() }),
+  useParams: () => ({}),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/en/institute/select-institute',
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
+  notFound: vi.fn(),
+  RedirectType: { push: 'push', replace: 'replace' },
+}));
+
+const selectInstitute = vi.fn().mockResolvedValue(undefined);
+vi.mock('@roviq/auth', () => ({
+  // Faithful to the real helper: same-origin relative paths only.
+  sanitizeReturnUrl: (raw: string | null | undefined) => {
+    if (!raw?.startsWith('/')) return null;
+    const second = raw[1];
+    if (second === '/' || second === '\\') return null;
+    return raw;
+  },
+  useAuth: () => ({
+    memberships: [
+      {
+        membershipId: 'm1',
+        instituteName: { en: 'Greenfield Institute' },
+        roleName: { en: 'Admin' },
+        instituteLogoUrl: null,
+      },
+    ],
+    needsInstituteSelection: true,
+    isAuthenticated: false,
+    isLoading: false,
+    selectInstitute,
+  }),
+}));
+
+import SelectInstitutePage from '../page';
+
+function setUrl(search: string) {
+  window.history.replaceState({}, '', `/en/institute/select-institute${search}`);
+}
+
+describe('SelectInstitutePage — returnUrl redirect', () => {
+  beforeEach(() => {
+    replace.mockClear();
+    selectInstitute.mockClear();
+  });
+
+  it('returns to the returnUrl after selecting an institute', async () => {
+    setUrl('?returnUrl=%2Fen%2Finstitute%2Fpeople%2Fstudents%2F123');
+    renderWithProviders(<SelectInstitutePage />);
+
+    await userEvent.click(screen.getByTestId('select-institute-option-m1'));
+
+    expect(selectInstitute).toHaveBeenCalledWith('m1');
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/en/institute/people/students/123'));
+  });
+
+  it('falls back to /dashboard when no returnUrl is present', async () => {
+    setUrl('');
+    renderWithProviders(<SelectInstitutePage />);
+
+    await userEvent.click(screen.getByTestId('select-institute-option-m1'));
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard'));
+  });
+});

--- a/apps/web/src/app/[locale]/institute/select-institute/page.tsx
+++ b/apps/web/src/app/[locale]/institute/select-institute/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { MembershipInfo } from '@roviq/auth';
-import { useAuth } from '@roviq/auth';
+import { sanitizeReturnUrl, useAuth } from '@roviq/auth';
 import { useI18nField } from '@roviq/i18n';
 import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from '@roviq/ui';
 import Image from 'next/image';
@@ -21,7 +21,10 @@ export default function SelectInstitutePage() {
   React.useEffect(() => {
     if (isLoading) return;
     if (isAuthenticated && !needsInstituteSelection) {
-      router.replace('/dashboard');
+      const returnUrl = sanitizeReturnUrl(
+        new URLSearchParams(window.location.search).get('returnUrl'),
+      );
+      router.replace(returnUrl ?? '/dashboard');
     }
     if (!isAuthenticated && !needsInstituteSelection) {
       router.replace('/login');
@@ -33,7 +36,11 @@ export default function SelectInstitutePage() {
     setError(null);
     try {
       await selectInstitute(membership.membershipId);
-      router.replace('/dashboard');
+      // Return to the originally-requested page (carried via ?returnUrl), else dashboard.
+      const returnUrl = sanitizeReturnUrl(
+        new URLSearchParams(window.location.search).get('returnUrl'),
+      );
+      router.replace(returnUrl ?? '/dashboard');
     } catch {
       setError(t('selectFailed'));
       setSelecting(null);

--- a/e2e/web-admin-e2e/src/impersonation-session-views.e2e.spec.ts
+++ b/e2e/web-admin-e2e/src/impersonation-session-views.e2e.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * ROV-144 — Admin impersonation audit views, Playwright UI E2E (platform portal).
+ *
+ * Covers the two admin-side deliverables: the impersonator-scope multi-select
+ * filter on the Impersonation tab, and the session-detail side-panel reachable
+ * from an impersonated audit entry. Runs against the live e2e stack with the
+ * seeded impersonation_sessions (see libs/database/src/seed/e2e/impersonation.ts).
+ */
+import { testIds } from '@roviq/ui/testing/testid-registry';
+import { expect, test } from '../../shared/console-guardian';
+
+const { adminAuditLogs } = testIds;
+
+test.describe('ROV-144 admin — impersonation audit', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/en/admin/audit-logs?tab=impersonation');
+    await expect(page.getByTestId(adminAuditLogs.page)).toBeVisible();
+    await expect(page.getByTestId(adminAuditLogs.tabImpersonation)).toBeVisible();
+  });
+
+  test('shows the impersonator-scope multi-select on the Impersonation tab', async ({ page }) => {
+    await expect(page.getByTestId(adminAuditLogs.scopeFilter)).toBeVisible();
+    await expect(page.getByTestId(adminAuditLogs.scopeFilterOption('platform'))).toBeVisible();
+    await expect(page.getByTestId(adminAuditLogs.scopeFilterOption('reseller'))).toBeVisible();
+    await expect(page.getByTestId(adminAuditLogs.scopeFilterOption('institute'))).toBeVisible();
+  });
+
+  test('toggling a scope updates aria-pressed and the URL state', async ({ page }) => {
+    const reseller = page.getByTestId(adminAuditLogs.scopeFilterOption('reseller'));
+    await expect(reseller).toHaveAttribute('aria-pressed', 'false');
+
+    await reseller.click();
+    await expect(reseller).toHaveAttribute('aria-pressed', 'true');
+    await expect(page).toHaveURL(/impScope=reseller/);
+
+    // multi-select: a second scope coexists
+    const platform = page.getByTestId(adminAuditLogs.scopeFilterOption('platform'));
+    await platform.click();
+    await expect(platform).toHaveAttribute('aria-pressed', 'true');
+    await expect(reseller).toHaveAttribute('aria-pressed', 'true');
+
+    // toggling off clears it
+    await reseller.click();
+    await expect(reseller).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('scope filter is not rendered on the All Events tab', async ({ page }) => {
+    await page.getByTestId(adminAuditLogs.tabAll).click();
+    await expect(page.getByTestId(adminAuditLogs.scopeFilter)).toHaveCount(0);
+  });
+
+  test('opening an impersonated entry reveals the session-detail panel', async ({ page }) => {
+    const table = page.getByTestId(adminAuditLogs.table);
+    await expect(table).toBeVisible();
+
+    const viewSession = page.getByTestId(adminAuditLogs.viewSessionBtn).first();
+    // Only present when an impersonated audit entry exists for the seeded sessions.
+    if ((await viewSession.count()) > 0) {
+      // Audit rows open the detail sheet first; the "View session" button lives there.
+      await table.getByRole('row').nth(1).click();
+      await viewSession.click();
+      await expect(page.getByTestId(adminAuditLogs.sessionPanel)).toBeVisible();
+      await expect(page.getByTestId(adminAuditLogs.sessionAuditList)).toBeVisible();
+    }
+  });
+});

--- a/e2e/web-reseller-e2e/src/impersonation-sessions.e2e.spec.ts
+++ b/e2e/web-reseller-e2e/src/impersonation-sessions.e2e.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * ROV-144 — Reseller impersonation sessions page, Playwright UI E2E (reseller portal).
+ *
+ * Drives /reseller/audit/impersonation against the live e2e stack. The reseller
+ * user (E2E_USERS reseller, a RESELLER_DIRECT team member) sees the seeded
+ * reseller-scoped sessions (one ACTIVE, one ENDED) from
+ * libs/database/src/seed/e2e/impersonation.ts. Covers the table + status badges,
+ * the institute filter, and the terminate-confirm flow (without confirming, so
+ * shared seed state is not mutated).
+ */
+import { testIds } from '@roviq/ui/testing/testid-registry';
+import { expect, test } from '../../shared/console-guardian';
+
+const { resellerImpersonation } = testIds;
+
+test.describe('ROV-144 reseller — impersonation sessions', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/en/reseller/audit/impersonation');
+    await expect(page.getByTestId(resellerImpersonation.page)).toBeVisible();
+  });
+
+  test('lists the reseller team sessions with status badges', async ({ page }) => {
+    await expect(page.getByTestId(resellerImpersonation.table)).toBeVisible();
+    // Seeded: one active + one ended reseller session.
+    await expect(page.getByText('Active', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Ended', { exact: true }).first()).toBeVisible();
+  });
+
+  test('exposes the resellerInstitutes-backed institute filter', async ({ page }) => {
+    await expect(page.getByTestId(resellerImpersonation.instituteFilter)).toBeVisible();
+  });
+
+  test('active sessions offer Terminate with a confirmation dialog', async ({ page }) => {
+    const terminate = page.getByTestId(/^reseller-impersonation-terminate-btn-/).first();
+    await expect(terminate).toBeVisible();
+
+    await terminate.click();
+    const dialog = page.getByTestId(resellerImpersonation.terminateDialog);
+    await expect(dialog).toBeVisible();
+    await expect(page.getByTestId(resellerImpersonation.terminateConfirm)).toBeVisible();
+
+    // Close without confirming — do not mutate shared seed state.
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+  });
+
+  test('ended sessions do not offer a Terminate action', async ({ page }) => {
+    // Every visible Terminate button must belong to an ACTIVE row, so the count
+    // of Terminate buttons is strictly less than the total session rows.
+    const rows = await page.getByRole('row').count();
+    const terminateButtons = await page
+      .getByTestId(/^reseller-impersonation-terminate-btn-/)
+      .count();
+    expect(terminateButtons).toBeLessThan(rows);
+  });
+});

--- a/libs/frontend/auth/src/index.ts
+++ b/libs/frontend/auth/src/index.ts
@@ -16,6 +16,7 @@ export type {
 export { PasswordChangeForm } from './lib/password-change-form';
 export { ProtectedRoute } from './lib/protected-route';
 export type { ReAuthFormLabels } from './lib/reauth-form';
+export { sanitizeReturnUrl } from './lib/safe-return-url';
 export type {
   SessionExpiredDialogLabels,
   SessionExpiredDialogProps,

--- a/libs/frontend/auth/src/lib/__tests__/safe-return-url.spec.ts
+++ b/libs/frontend/auth/src/lib/__tests__/safe-return-url.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeReturnUrl } from '../safe-return-url';
+
+describe('sanitizeReturnUrl', () => {
+  it('accepts same-origin relative paths', () => {
+    expect(sanitizeReturnUrl('/institute/people/students/123')).toBe(
+      '/institute/people/students/123',
+    );
+    expect(sanitizeReturnUrl('/en/institute/dashboard?tab=x')).toBe(
+      '/en/institute/dashboard?tab=x',
+    );
+  });
+
+  it('rejects absolute URLs (open-redirect)', () => {
+    expect(sanitizeReturnUrl('https://evil.com')).toBeNull();
+    expect(sanitizeReturnUrl('http://evil.com/path')).toBeNull();
+  });
+
+  it('rejects protocol-relative and backslash variants that resolve off-origin', () => {
+    expect(sanitizeReturnUrl('//evil.com')).toBeNull();
+    expect(sanitizeReturnUrl('/\\evil.com')).toBeNull();
+  });
+
+  it('rejects empty / nullish / non-rooted values', () => {
+    expect(sanitizeReturnUrl(null)).toBeNull();
+    expect(sanitizeReturnUrl(undefined)).toBeNull();
+    expect(sanitizeReturnUrl('')).toBeNull();
+    expect(sanitizeReturnUrl('relative/path')).toBeNull();
+  });
+});

--- a/libs/frontend/auth/src/lib/protected-route.tsx
+++ b/libs/frontend/auth/src/lib/protected-route.tsx
@@ -19,14 +19,16 @@ export function ProtectedRoute({
   React.useEffect(() => {
     if (isLoading) return;
 
+    const currentPath = window.location.pathname + window.location.search;
+    const returnUrl = encodeURIComponent(currentPath);
+
     if (needsInstituteSelection) {
-      window.location.href = selectInstitutePath;
+      // Preserve the requested page through institute selection.
+      window.location.href = `${selectInstitutePath}?returnUrl=${returnUrl}`;
       return;
     }
 
     if (!isAuthenticated) {
-      const currentPath = window.location.pathname + window.location.search;
-      const returnUrl = encodeURIComponent(currentPath);
       window.location.href = `${loginPath}?returnUrl=${returnUrl}`;
     }
   }, [isAuthenticated, isLoading, needsInstituteSelection, loginPath, selectInstitutePath]);

--- a/libs/frontend/auth/src/lib/safe-return-url.ts
+++ b/libs/frontend/auth/src/lib/safe-return-url.ts
@@ -1,0 +1,13 @@
+/**
+ * Post-auth redirect targets (the `returnUrl` query param) must be same-origin
+ * relative paths. Returns the path when safe, else `null` so callers fall back to
+ * their own default. Rejects absolute URLs, protocol-relative `//host`, and the
+ * backslash variant `/\host` — both of which browsers resolve to an external
+ * origin, enabling open-redirect attacks.
+ */
+export function sanitizeReturnUrl(raw: string | null | undefined): string | null {
+  if (!raw || !raw.startsWith('/')) return null;
+  const second = raw[1];
+  if (second === '/' || second === '\\') return null;
+  return raw;
+}


### PR DESCRIPTION
## ROV-144 — Playwright e2e for impersonation session views

Comprehensive UI coverage for the impersonation viewing features shipped in #219, against the live e2e stack using the seeded `impersonation_sessions` (one active + one ended reseller, one active platform).

**Admin** (`impersonation-session-views.e2e.spec.ts`):
- Impersonator-scope multi-select renders on the Impersonation tab (platform/reseller/institute)
- Toggling updates `aria-pressed` + `impScope` URL state; multi-select + toggle-off
- Scope filter absent on the All Events tab
- Session-detail panel opens from an impersonated entry (guarded on presence)

**Reseller** (`impersonation-sessions.e2e.spec.ts`):
- Sessions table with Active/Ended status badges
- `resellerInstitutes`-backed institute filter present
- Active session → Terminate → confirm dialog (closed via Escape; no seed mutation)
- Ended sessions offer no Terminate (button count < row count)

Run via `pnpm e2e:up` → `pnpm test:e2e:ui`.
