### PR TITLE
feat(audit): reseller name + tier on audit entries + admin/reseller UI (ROV-145)

### DIFF
--- a/apps/api-gateway/src/audit/models/audit-log.model.ts
+++ b/apps/api-gateway/src/audit/models/audit-log.model.ts
@@ -70,4 +70,12 @@ export class AuditLog {
 
   @Field(() => I18nTextScalar, { nullable: true })
   tenantName!: I18nContent | null;
+
+  /** Reseller display name (joined on resellers.id). Null for non-reseller-scoped entries. */
+  @Field(() => String, { nullable: true })
+  resellerName!: string | null;
+
+  /** Reseller tier (FULL_MANAGEMENT / SUPPORT_MANAGEMENT / READ_ONLY). Null when no reseller. */
+  @Field(() => String, { nullable: true })
+  resellerTier!: string | null;
 }

--- a/apps/api-gateway/src/audit/repositories/audit-query.drizzle-repository.ts
+++ b/apps/api-gateway/src/audit/repositories/audit-query.drizzle-repository.ts
@@ -9,6 +9,7 @@ import {
   mkAdminCtx,
   mkInstituteCtx,
   mkResellerCtx,
+  resellersLive,
   users,
   withAdmin,
   withReseller,
@@ -139,11 +140,14 @@ export class AuditQueryDrizzleRepository extends AuditQueryRepository {
           actorName: actor.username,
           userName: userAlias.username,
           tenantName: institutes.name,
+          resellerName: resellersLive.name,
+          resellerTier: resellersLive.tier,
         })
         .from(auditLogs)
         .leftJoin(actor, eq(actor.id, auditLogs.actorId))
         .leftJoin(userAlias, eq(userAlias.id, auditLogs.userId))
         .leftJoin(institutes, eq(institutes.id, auditLogs.tenantId))
+        .leftJoin(resellersLive, eq(resellersLive.id, auditLogs.resellerId))
         .$dynamic();
 
       let countQuery = tx.select({ total: count() }).from(auditLogs).$dynamic();
@@ -247,6 +251,8 @@ export class AuditQueryDrizzleRepository extends AuditQueryRepository {
     actorName: string | null;
     userName: string | null;
     tenantName: Record<string, string> | null;
+    resellerName: string | null;
+    resellerTier: string | null;
   }): AuditLogRow {
     return {
       id: row.id,
@@ -272,6 +278,8 @@ export class AuditQueryDrizzleRepository extends AuditQueryRepository {
       actorName: row.actorName ?? null,
       userName: row.userName ?? null,
       tenantName: row.tenantName ?? null,
+      resellerName: row.resellerName ?? null,
+      resellerTier: row.resellerTier ?? null,
     };
   }
 }

--- a/apps/api-gateway/src/audit/repositories/types.ts
+++ b/apps/api-gateway/src/audit/repositories/types.ts
@@ -27,6 +27,9 @@ export interface AuditLogRow {
   actorName: string | null;
   userName: string | null;
   tenantName: I18nContent | null;
+  /** Resolved reseller display name + tier (joined on resellers.id). Null when resellerId is null. */
+  resellerName: string | null;
+  resellerTier: string | null;
 }
 
 export interface AuditEventData {

--- a/apps/web/messages/en/auditLogs.json
+++ b/apps/web/messages/en/auditLogs.json
@@ -10,7 +10,14 @@
     "entityId": "Entity ID",
     "source": "Source",
     "ipAddress": "IP Address",
-    "institute": "Institute"
+    "institute": "Institute",
+    "reseller": "Reseller",
+    "resellerTier": "Tier"
+  },
+  "resellerTier": {
+    "FULL_MANAGEMENT": "Full management",
+    "SUPPORT_MANAGEMENT": "Support",
+    "READ_ONLY": "Read-only"
   },
   "filters": {
     "entityType": "Entity type",

--- a/apps/web/messages/hi/auditLogs.json
+++ b/apps/web/messages/hi/auditLogs.json
@@ -10,7 +10,14 @@
     "entityId": "इकाई ID",
     "source": "स्रोत",
     "ipAddress": "IP पता",
-    "institute": "संस्थान"
+    "institute": "संस्थान",
+    "reseller": "रिसेलर",
+    "resellerTier": "स्तर"
+  },
+  "resellerTier": {
+    "FULL_MANAGEMENT": "पूर्ण प्रबंधन",
+    "SUPPORT_MANAGEMENT": "सहायता",
+    "READ_ONLY": "केवल-पढ़ने योग्य"
   },
   "filters": {
     "entityType": "इकाई प्रकार",

--- a/apps/web/src/app/[locale]/admin/(dashboard)/audit-logs/__tests__/audit-log-columns.spec.tsx
+++ b/apps/web/src/app/[locale]/admin/(dashboard)/audit-logs/__tests__/audit-log-columns.spec.tsx
@@ -1,0 +1,33 @@
+/**
+ * ROV-145 — unit test for the audit-log column factory's reseller columns.
+ *
+ * The Reseller Activity tab passes `showReseller = true` to surface the resolved
+ * reseller name + tier badge; other tabs must not include those columns.
+ */
+import type { ColumnDef } from '@tanstack/react-table';
+import { describe, expect, it } from 'vitest';
+import { createAuditLogColumns } from '../audit-log-columns';
+import type { AuditLogNode } from '../use-audit-logs';
+
+const t = (key: string) => key;
+const formatDate = (date: Date) => date.toISOString();
+
+function accessorKeys(cols: ColumnDef<AuditLogNode, unknown>[]): string[] {
+  return cols.flatMap((c) => ('accessorKey' in c && c.accessorKey ? [String(c.accessorKey)] : []));
+}
+
+describe('createAuditLogColumns', () => {
+  it('omits reseller columns by default', () => {
+    const keys = accessorKeys(createAuditLogColumns(t, formatDate));
+
+    expect(keys).not.toContain('resellerName');
+    expect(keys).not.toContain('resellerTier');
+  });
+
+  it('adds reseller name + tier columns when showReseller is true', () => {
+    const keys = accessorKeys(createAuditLogColumns(t, formatDate, true));
+
+    expect(keys).toContain('resellerName');
+    expect(keys).toContain('resellerTier');
+  });
+});

--- a/apps/web/src/app/[locale]/admin/(dashboard)/audit-logs/audit-log-columns.tsx
+++ b/apps/web/src/app/[locale]/admin/(dashboard)/audit-logs/audit-log-columns.tsx
@@ -23,10 +23,46 @@ const ACTION_TYPE_VARIANT: Record<string, 'default' | 'secondary' | 'destructive
   ACTIVATE: 'default',
 };
 
+/** Tier badge colour: full=green, support=blue, read-only=grey. */
+const TIER_BADGE_CLASS: Record<string, string> = {
+  FULL_MANAGEMENT: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300',
+  SUPPORT_MANAGEMENT: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
+  READ_ONLY: 'bg-muted text-muted-foreground',
+};
+
 export function createAuditLogColumns(
   t: (key: string) => string,
   formatDate: (date: Date) => string,
+  showReseller = false,
 ): ColumnDef<AuditLogNode, unknown>[] {
+  const resellerColumns: ColumnDef<AuditLogNode, unknown>[] = showReseller
+    ? [
+        {
+          accessorKey: 'resellerName',
+          header: t('columns.reseller'),
+          cell: ({ row }) => (
+            <span className="max-w-[160px] truncate text-sm">
+              {row.original.resellerName ?? '—'}
+            </span>
+          ),
+        },
+        {
+          accessorKey: 'resellerTier',
+          header: t('columns.resellerTier'),
+          cell: ({ row }) => {
+            const tier = row.original.resellerTier;
+            return tier ? (
+              <Badge variant="outline" className={TIER_BADGE_CLASS[tier] ?? ''}>
+                {t(`resellerTier.${tier}`)}
+              </Badge>
+            ) : (
+              <span className="text-muted-foreground">—</span>
+            );
+          },
+        },
+      ]
+    : [];
+
   return [
     {
       accessorKey: 'createdAt',
@@ -57,6 +93,7 @@ export function createAuditLogColumns(
         );
       },
     },
+    ...resellerColumns,
     {
       accessorKey: 'action',
       header: t('columns.action'),

--- a/apps/web/src/app/[locale]/admin/(dashboard)/audit-logs/page.tsx
+++ b/apps/web/src/app/[locale]/admin/(dashboard)/audit-logs/page.tsx
@@ -68,7 +68,10 @@ export default function AuditLogsPage() {
     [format],
   );
 
-  const columns = React.useMemo(() => createAuditLogColumns(t, formatDate), [t, formatDate]);
+  const columns = React.useMemo(
+    () => createAuditLogColumns(t, formatDate, activeTab === 'reseller'),
+    [t, formatDate, activeTab],
+  );
 
   const handleLoadMore = async () => {
     setIsLoadingMore(true);

--- a/apps/web/src/app/[locale]/admin/(dashboard)/audit-logs/use-audit-logs.ts
+++ b/apps/web/src/app/[locale]/admin/(dashboard)/audit-logs/use-audit-logs.ts
@@ -31,6 +31,8 @@ const ADMIN_AUDIT_LOGS_QUERY = gql`
           actorName
           userName
           tenantName
+          resellerName
+          resellerTier
         }
       }
       totalCount

--- a/apps/web/src/app/[locale]/reseller/(dashboard)/audit/page.tsx
+++ b/apps/web/src/app/[locale]/reseller/(dashboard)/audit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useFormatDate, useI18nField } from '@roviq/i18n';
 import {
+  Badge,
   Button,
   Can,
   DataTable,
@@ -12,12 +13,20 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '@roviq/ui';
+import { testIds } from '@roviq/ui/testing/testid-registry';
 import { ScrollText, SearchX, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import * as React from 'react';
 import { createResellerAuditLogColumns } from './audit-log-columns';
 import { ResellerAuditLogFilters, useResellerAuditLogFilters } from './audit-log-filters';
 import { useResellerAuditLogs } from './use-reseller-audit-logs';
+
+/** Tier badge colour: full=green, support=blue, read-only=grey. */
+const TIER_BADGE_CLASS: Record<string, string> = {
+  FULL_MANAGEMENT: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300',
+  SUPPORT_MANAGEMENT: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
+  READ_ONLY: 'bg-muted text-muted-foreground',
+};
 
 export default function ResellerAuditLogsPage() {
   const t = useTranslations('auditLogs');
@@ -67,6 +76,20 @@ export default function ResellerAuditLogsPage() {
       <div>
         <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
         <p className="text-muted-foreground">{t('description')}</p>
+        {logs[0]?.resellerName && (
+          <div
+            className="mt-1 flex items-center gap-2 text-sm"
+            data-testid={testIds.resellerAudit.resellerContext}
+          >
+            <span className="text-muted-foreground">{t('columns.reseller')}:</span>
+            <span className="font-medium">{logs[0].resellerName}</span>
+            {logs[0].resellerTier && (
+              <Badge variant="outline" className={TIER_BADGE_CLASS[logs[0].resellerTier] ?? ''}>
+                {t(`resellerTier.${logs[0].resellerTier}`)}
+              </Badge>
+            )}
+          </div>
+        )}
       </div>
 
       <Can I="read" a="AuditLog" passThrough>

--- a/apps/web/src/app/[locale]/reseller/(dashboard)/audit/use-reseller-audit-logs.ts
+++ b/apps/web/src/app/[locale]/reseller/(dashboard)/audit/use-reseller-audit-logs.ts
@@ -47,6 +47,8 @@ const RESELLER_AUDIT_LOGS_QUERY = gql`
           actorName
           userName
           tenantName
+          resellerName
+          resellerTier
         }
       }
       totalCount

--- a/libs/frontend/ui/src/testing/testid-registry.ts
+++ b/libs/frontend/ui/src/testing/testid-registry.ts
@@ -175,6 +175,11 @@ export const testIds = {
     sessionAuditList: 'audit-logs-session-audit-list',
   },
 
+  // ── Reseller: audit logs page (ROV-145) ───────────────────────────────
+  resellerAudit: {
+    resellerContext: 'reseller-audit-context',
+  },
+
   // ── Reseller: impersonation sessions page (ROV-144) ───────────────────
   resellerImpersonation: {
     page: 'reseller-impersonation-page',
@@ -345,6 +350,9 @@ export const testIds = {
     attendanceKpiByStatus: (status: string) => `dashboard-attendance-kpi-${status}`,
     todayScheduleCard: 'dashboard-today-schedule-card',
     todayScheduleLink: 'dashboard-today-schedule-link',
+    examsCard: 'dashboard-exams-card',
+    examsCardLink: 'dashboard-exams-card-link',
+    examsCardRow: (id: string) => `dashboard-exams-card-row-${id}`,
   },
 
   // ── Institute: students list + detail ──────────────────────────────────
@@ -385,6 +393,7 @@ export const testIds = {
     detailAcademicsEmpty: 'students-detail-academics-empty',
     detailTitle: 'students-detail-title',
     detailViewTimetableLink: 'students-detail-view-timetable-link',
+    detailViewExamsLink: 'students-detail-view-exams-link',
     detailDraftDiscardBtn: 'students-detail-draft-discard-btn',
     detailDraftRestoreBtn: 'students-detail-draft-restore-btn',
     detailResetBtn: 'students-detail-reset-btn',
@@ -1003,6 +1012,7 @@ export const testIds = {
     archiveBtn: 'exam-archive-btn',
     // Datesheet
     datesheet: 'exam-datesheet',
+    datesheetDownloadBtn: 'exam-datesheet-download-btn',
     addScheduleBtn: 'exam-add-schedule-btn',
     scheduleRow: (id: string) => `exam-schedule-row-${id}`,
     scheduleStandardSelect: 'exam-schedule-standard-select',
@@ -1043,6 +1053,10 @@ export const testIds = {
     reportCardDownloadBtn: (id: string) => `report-card-download-${id}-btn`,
     reportCardInstanceRow: (id: string) => `report-card-instance-${id}-row`,
     myReportCardsPage: 'my-report-cards-page',
+    myReportCardsTitle: 'my-report-cards-title',
+    myReportCardRow: (id: string) => `my-report-card-row-${id}`,
+    myReportCardDownloadBtn: (id: string) => `my-report-card-download-${id}-btn`,
+    myReportCardsEmpty: 'my-report-cards-empty',
   },
 
   // ── Institute: select institute ────────────────────────────────────────


### PR DESCRIPTION
Resolved reseller name + tier on audit entries (admin Reseller-Activity columns + tier badge; reseller-portal header). Backend repo JOIN on resellersLive (RLS-scoped), exposed on AuditLog. Supersedes #220 (rebased onto develop to drop duplicate ROV-144 commits). Column-factory + i18n tests.